### PR TITLE
[LHAC-V2-2] Chronological sort fix for Community Page

### DIFF
--- a/app/community/detail/page.tsx
+++ b/app/community/detail/page.tsx
@@ -1,19 +1,9 @@
-<<<<<<< HEAD
-export const dynamic = 'force-dynamic';
-
-=======
->>>>>>> 5bd1e1b (Connect Community page to /api/engagements and render detail view and added component to navbar)
 import { DetailRenderer } from './renderer';
 import { Suspense } from 'react';
 import { CommunityEvent } from '@/types/event';
 
 export default async function EventDetailPage() {
-<<<<<<< HEAD
-  const baseURL = process.env.BASE_URL ?? ''
-  const res = await fetch(baseURL + '/api/engagements', {
-=======
   const res = await fetch('http://localhost:3000/api/engagements', {
->>>>>>> 5bd1e1b (Connect Community page to /api/engagements and render detail view and added component to navbar)
     next: { revalidate: 60 },
   });
 
@@ -21,11 +11,7 @@ export default async function EventDetailPage() {
     throw new Error('Failed to load event details');
   }
 
-<<<<<<< HEAD
-  const events: CommunityEvent[] = (await res.json()) as CommunityEvent[];
-=======
   const events: CommunityEvent[] = await res.json();
->>>>>>> 5bd1e1b (Connect Community page to /api/engagements and render detail view and added component to navbar)
 
   return (
     <Suspense fallback={<p className="text-white p-4">Loading event...</p>}>

--- a/app/community/detail/page.tsx
+++ b/app/community/detail/page.tsx
@@ -1,12 +1,19 @@
+<<<<<<< HEAD
 export const dynamic = 'force-dynamic';
 
+=======
+>>>>>>> 5bd1e1b (Connect Community page to /api/engagements and render detail view and added component to navbar)
 import { DetailRenderer } from './renderer';
 import { Suspense } from 'react';
 import { CommunityEvent } from '@/types/event';
 
 export default async function EventDetailPage() {
+<<<<<<< HEAD
   const baseURL = process.env.BASE_URL ?? ''
   const res = await fetch(baseURL + '/api/engagements', {
+=======
+  const res = await fetch('http://localhost:3000/api/engagements', {
+>>>>>>> 5bd1e1b (Connect Community page to /api/engagements and render detail view and added component to navbar)
     next: { revalidate: 60 },
   });
 
@@ -14,7 +21,11 @@ export default async function EventDetailPage() {
     throw new Error('Failed to load event details');
   }
 
+<<<<<<< HEAD
   const events: CommunityEvent[] = (await res.json()) as CommunityEvent[];
+=======
+  const events: CommunityEvent[] = await res.json();
+>>>>>>> 5bd1e1b (Connect Community page to /api/engagements and render detail view and added component to navbar)
 
   return (
     <Suspense fallback={<p className="text-white p-4">Loading event...</p>}>

--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -10,32 +10,24 @@ interface CommunityEvent {
 }
 
 export default async function CommunityPage() {
-<<<<<<< HEAD
-  const baseURL = process.env.BASE_URL ?? ''
-  const res = await fetch(baseURL + '/api/engagements', {
-=======
   const res = await fetch('http://localhost:3000/api/engagements', {
->>>>>>> 5bd1e1b (Connect Community page to /api/engagements and render detail view and added component to navbar)
-    cache: 'no-store', // Optional: disables caching for fresh data
+    cache: 'no-store',
   });
 
   if (!res.ok) {
     throw new Error('Failed to fetch community events');
   }
 
-<<<<<<< HEAD
-  const events: CommunityEvent[] = (await res.json()) as CommunityEvent[];
-  const now = new Date();
-
-  const pastEvents = events.filter(e => new Date(e.date) < now).sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
-  const futureEvents = events.filter(e => new Date(e.date) >= now).sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
-=======
   const events: CommunityEvent[] = await res.json();
   const now = new Date();
 
-  const pastEvents = events.filter(e => new Date(e.date) < now);
-  const futureEvents = events.filter(e => new Date(e.date) >= now);
->>>>>>> 5bd1e1b (Connect Community page to /api/engagements and render detail view and added component to navbar)
+  const pastEvents = events
+    .filter(e => new Date(e.date) < now)
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()); // Descending
+
+  const futureEvents = events
+    .filter(e => new Date(e.date) >= now)
+    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()); // Ascending
 
   return (
     <div className="w-full max-w-5xl mx-auto px-4 py-8">

--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -10,8 +10,12 @@ interface CommunityEvent {
 }
 
 export default async function CommunityPage() {
+<<<<<<< HEAD
   const baseURL = process.env.BASE_URL ?? ''
   const res = await fetch(baseURL + '/api/engagements', {
+=======
+  const res = await fetch('http://localhost:3000/api/engagements', {
+>>>>>>> 5bd1e1b (Connect Community page to /api/engagements and render detail view and added component to navbar)
     cache: 'no-store', // Optional: disables caching for fresh data
   });
 
@@ -19,11 +23,19 @@ export default async function CommunityPage() {
     throw new Error('Failed to fetch community events');
   }
 
+<<<<<<< HEAD
   const events: CommunityEvent[] = (await res.json()) as CommunityEvent[];
   const now = new Date();
 
   const pastEvents = events.filter(e => new Date(e.date) < now).sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
   const futureEvents = events.filter(e => new Date(e.date) >= now).sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+=======
+  const events: CommunityEvent[] = await res.json();
+  const now = new Date();
+
+  const pastEvents = events.filter(e => new Date(e.date) < now);
+  const futureEvents = events.filter(e => new Date(e.date) >= now);
+>>>>>>> 5bd1e1b (Connect Community page to /api/engagements and render detail view and added component to navbar)
 
   return (
     <div className="w-full max-w-5xl mx-auto px-4 py-8">

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
                 "clsx": "^2.1.1",
                 "cookie": "^1.0.2",
                 "date-fns": "^4.1.0",
-                "jose": "^6.0.10",
+                "jose": "^6.0.11",
                 "jsonwebtoken": "^9.0.2",
                 "lucide-react": "^0.464.0",
                 "multer": "^1.4.5-lts.2",
@@ -7511,9 +7511,9 @@
             }
         },
         "node_modules/jose": {
-            "version": "6.0.10",
-            "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.10.tgz",
-            "integrity": "sha512-skIAxZqcMkOrSwjJvplIPYrlXGpxTPnro2/QWTDCxAdWQrSTV5/KqspMWmi5WAx5+ULswASJiZ0a+1B/Lxt9cw==",
+            "version": "6.0.11",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.11.tgz",
+            "integrity": "sha512-QxG7EaliDARm1O1S8BGakqncGT9s25bKL1WSf6/oa17Tkqwi8D2ZNglqCF+DsYF88/rV66Q/Q2mFAy697E1DUg==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/panva"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "clsx": "^2.1.1",
         "cookie": "^1.0.2",
         "date-fns": "^4.1.0",
-        "jose": "^6.0.10",
+        "jose": "^6.0.11",
         "jsonwebtoken": "^9.0.2",
         "lucide-react": "^0.464.0",
         "multer": "^1.4.5-lts.2",


### PR DESCRIPTION
## Summary

Sorted events on the `/community` page chronologically:

* Future events are displayed in ascending order (soonest first)
* Past events are displayed in descending order (most recent first)

This change ensures users see upcoming events first and the most recent past events prominently.

## Usage

No new routes or components introduced. Sorting logic has been updated in `app/community/page.tsx`.

To test:

1. Navigate to `/community`
2. Verify upcoming events appear in chronological order
3. Verify past events appear in reverse chronological order

## UI Changes

None. The visual structure and styling remain unchanged.

<!-- Screenshots are not necessary for this logic-only update. -->
